### PR TITLE
sync to git version 8369e39

### DIFF
--- a/raspberrypi-vc-demo-source-path-fixup.patch
+++ b/raspberrypi-vc-demo-source-path-fixup.patch
@@ -1,70 +1,70 @@
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_audio/audio.c raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_audio/audio.c
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_audio/audio.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_audio/audio.c	2015-03-08 11:14:43.518965889 +0000
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_audio/audio.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_audio/audio.c
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_audio/audio.c	2014-08-08 15:48:27.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_audio/audio.c	2015-03-08 11:14:43.518965889 +0000
 @@ -34,7 +34,7 @@
  #include <unistd.h>
  #include <semaphore.h>
- 
+
 -#include "bcm_host.h"
 +#include <bcm_host.h>
  #include "ilclient.h"
- 
+
  #define N_WAVE          1024    /* dimension of Sinewave[] */
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_dispmanx/dispmanx.c raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_dispmanx/dispmanx.c
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_dispmanx/dispmanx.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_dispmanx/dispmanx.c	2015-03-08 11:14:43.518965889 +0000
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_dispmanx/dispmanx.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_dispmanx/dispmanx.c
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_dispmanx/dispmanx.c	2014-08-08 15:48:27.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_dispmanx/dispmanx.c	2015-03-08 11:14:43.518965889 +0000
 @@ -34,7 +34,7 @@
  #include <unistd.h>
  #include <sys/time.h>
- 
+
 -#include "bcm_host.h"
 +#include <bcm_host.h>
- 
+
  #define WIDTH   200
  #define HEIGHT  200
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_encode/encode.c raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_encode/encode.c
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_encode/encode.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_encode/encode.c	2015-03-08 11:21:13.318328860 +0000
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_encode/encode.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_encode/encode.c
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_encode/encode.c	2014-08-08 15:48:27.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_encode/encode.c	2015-03-08 11:21:13.318328860 +0000
 @@ -33,7 +33,7 @@
  #include <stdlib.h>
  #include <string.h>
- 
+
 -#include "bcm_host.h"
 +#include <bcm_host.h>
  #include "ilclient.h"
- 
+
  #define NUMFRAMES 300
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_font/main.c raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_font/main.c
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_font/main.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_font/main.c	2015-03-08 11:21:38.953944627 +0000
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_font/main.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_font/main.c
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_font/main.c	2014-08-08 15:48:27.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_font/main.c	2015-03-08 11:21:38.953944627 +0000
 @@ -33,7 +33,7 @@
  #include <assert.h>
  #include <unistd.h>
- 
+
 -#include "bcm_host.h"
 +#include <bcm_host.h>
  #include "vgfont.h"
- 
+
  static const char *strnchr(const char *str, size_t len, char c)
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_jpeg/jpeg.h raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_jpeg/jpeg.h
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_jpeg/jpeg.h	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_jpeg/jpeg.h	2015-03-08 11:22:19.159910374 +0000
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_jpeg/jpeg.h raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_jpeg/jpeg.h
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_jpeg/jpeg.h	2014-08-08 15:48:27.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_jpeg/jpeg.h	2015-03-08 11:22:19.159910374 +0000
 @@ -40,7 +40,7 @@
  #include <string.h>
  #include <errno.h>
- 
+
 -#include "bcm_host.h"
 +#include <bcm_host.h>
  #include "ilclient.h"
- 
+
  #define OMXJPEG_OK                  0
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_teapot/models.c raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_teapot/models.c
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_teapot/models.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_teapot/models.c	2015-03-08 11:27:36.987544586 +0000
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_teapot/models.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_teapot/models.c
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_teapot/models.c	2014-08-08 15:48:27.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_teapot/models.c	2015-03-08 11:27:36.987544586 +0000
 @@ -29,9 +29,9 @@
  #include <stdio.h>
  #include <stdint.h>
- 
+
 -#include "GLES/gl.h"
 -#include "EGL/egl.h"
 -#include "EGL/eglext.h"
@@ -72,45 +72,45 @@ diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi
 +#include <EGL/egl.h>
 +#include <EGL/eglext.h>
  #include "models.h"
- 
+
  #define VMCS_RESOURCE(a,b) (b)
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c	2015-03-08 11:27:10.751914406 +0000
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c	2014-08-08 15:48:27.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c	2015-03-08 11:27:10.751914406 +0000
 @@ -35,11 +35,11 @@
  #include <assert.h>
  #include <unistd.h>
- 
+
 -#include "bcm_host.h"
 +#include <bcm_host.h>
- 
+
 -#include "GLES/gl.h"
 -#include "EGL/egl.h"
 -#include "EGL/eglext.h"
 +#include <GLES/gl.h>
 +#include <EGL/egl.h>
 +#include <EGL/eglext.h>
- 
+
  #include "cube_texture_and_coords.h"
  #include "models.h"
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_teapot/video.c raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_teapot/video.c
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_teapot/video.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_teapot/video.c	2015-03-08 11:22:40.915432941 +0000
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_teapot/video.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_teapot/video.c
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_teapot/video.c	2014-08-08 15:48:27.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_teapot/video.c	2015-03-08 11:22:40.915432941 +0000
 @@ -32,7 +32,7 @@
  #include <stdlib.h>
  #include <string.h>
- 
+
 -#include "bcm_host.h"
 +#include <bcm_host.h>
  #include "ilclient.h"
- 
+
  static OMX_BUFFERHEADERTYPE* eglBuffer = NULL;
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_tiger/main.c raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_tiger/main.c
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_tiger/main.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_tiger/main.c	2015-03-08 11:28:31.458852985 +0000
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_tiger/main.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_tiger/main.c
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_tiger/main.c	2014-08-08 15:48:27.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_tiger/main.c	2015-03-08 11:28:31.458852985 +0000
 @@ -41,13 +41,13 @@
  #define UNREF(X) ((void)(X))
- 
+
  #ifdef HG_FLAT_INCLUDES
 -#	include "openvg.h"
 -#	include "vgu.h"
@@ -126,159 +126,159 @@ diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi
 +#	include <VG/vgu.h>
 +#	include <EGL/egl.h>
  #endif
- 
+
  #include "tiger.h"
 @@ -479,7 +479,7 @@
  //TODO
- 
+
  #elif defined __RASPBERRYPI__
 -#include "bcm_host.h"
 +#include <bcm_host.h>
  int main(void)
  {
     uint32_t width, height;
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_triangle/triangle.c raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_triangle/triangle.c
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_triangle/triangle.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_triangle/triangle.c	2015-03-08 11:29:00.839558709 +0000
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_triangle/triangle.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_triangle/triangle.c
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_triangle/triangle.c	2014-08-08 15:48:27.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_triangle/triangle.c	2015-03-08 11:29:00.839558709 +0000
 @@ -34,11 +34,11 @@
  #include <assert.h>
  #include <unistd.h>
- 
+
 -#include "bcm_host.h"
 +#include <bcm_host.h>
- 
+
 -#include "GLES/gl.h"
 -#include "EGL/egl.h"
 -#include "EGL/eglext.h"
 +#include <GLES/gl.h>
 +#include <EGL/egl.h>
 +#include <EGL/eglext.h>
- 
+
  #include "cube_texture_and_coords.h"
- 
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c	2015-03-08 11:14:43.523966009 +0000
+
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c	2014-08-08 15:48:27.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c	2015-03-08 11:14:43.523966009 +0000
 @@ -36,11 +36,11 @@
  #include <assert.h>
  #include <unistd.h>
- 
+
 -#include "bcm_host.h"
 +#include <bcm_host.h>
- 
+
 -#include "GLES2/gl2.h"
 -#include "EGL/egl.h"
 -#include "EGL/eglext.h"
 +#include <GLES2/gl2.h>
 +#include <EGL/egl.h>
 +#include <EGL/eglext.h>
- 
+
  typedef struct
  {
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_video/video.c raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_video/video.c
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_video/video.c	2014-08-08 15:48:28.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_video/video.c	2015-03-08 11:14:43.528966129 +0000
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_video/video.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_video/video.c
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_video/video.c	2014-08-08 15:48:28.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_video/video.c	2015-03-08 11:14:43.528966129 +0000
 @@ -31,7 +31,7 @@
  #include <stdlib.h>
  #include <string.h>
- 
+
 -#include "bcm_host.h"
 +#include <bcm_host.h>
  #include "ilclient.h"
- 
+
  static int video_decode_test(char *filename)
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c	2014-08-08 15:48:28.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c	2015-03-08 11:29:38.625466325 +0000
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c	2014-08-08 15:48:28.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c	2015-03-08 11:29:38.625466325 +0000
 @@ -35,11 +35,11 @@
  #include <assert.h>
  #include <unistd.h>
- 
+
 -#include "bcm_host.h"
 +#include <bcm_host.h>
- 
+
 -#include "GLES/gl.h"
 -#include "EGL/egl.h"
 -#include "EGL/eglext.h"
 +#include <GLES/gl.h>
 +#include <EGL/egl.h>
 +#include <EGL/eglext.h>
- 
+
  #include "cube_texture_and_coords.h"
- 
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_videocube/video.c raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_videocube/video.c
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/hello_videocube/video.c	2014-08-08 15:48:28.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/hello_videocube/video.c	2015-03-08 11:24:28.093007343 +0000
+
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_videocube/video.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_videocube/video.c
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_videocube/video.c	2014-08-08 15:48:28.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_videocube/video.c	2015-03-08 11:24:28.093007343 +0000
 @@ -32,7 +32,7 @@
  #include <stdlib.h>
  #include <string.h>
- 
+
 -#include "bcm_host.h"
 +#include <bcm_host.h>
  #include "ilclient.h"
- 
+
  static OMX_BUFFERHEADERTYPE* eglBuffer = NULL;
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.c raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.c
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.c	2014-08-08 15:48:28.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.c	2015-03-08 11:33:36.606182617 +0000
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.c
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.c	2014-08-08 15:48:28.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.c	2015-03-08 11:33:36.606182617 +0000
 @@ -47,11 +47,11 @@
  #include <ctype.h>
  #include <assert.h>
- 
+
 -#include "interface/vcos/vcos.h"
 -#include "interface/vcos/vcos_logging.h"
 -#include "interface/vmcs_host/vchost.h"
 +#include <interface/vcos/vcos.h>
 +#include <interface/vcos/vcos_logging.h>
 +#include <interface/vmcs_host/vchost.h>
- 
+
 -#include "IL/OMX_Broadcom.h"
 +#include <IL/OMX_Broadcom.h>
  #include "ilclient.h"
- 
+
  #define VCOS_LOG_CATEGORY (&ilclient_log_category)
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.h raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.h
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.h	2014-08-08 15:48:28.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.h	2015-03-08 11:34:04.476852069 +0000
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.h raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.h
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.h	2014-08-08 15:48:28.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.h	2015-03-08 11:34:04.476852069 +0000
 @@ -43,8 +43,8 @@
  #ifndef _IL_CLIENT_H
  #define _IL_CLIENT_H
- 
+
 -#include "IL/OMX_Broadcom.h"
 -#include "interface/vcos/vcos.h"
 +#include <IL/OMX_Broadcom.h>
 +#include <interface/vcos/vcos.h>
- 
+
  /**
   * The <DFN>ILCLIENT_T</DFN> structure encapsulates the state needed for the IL
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilcore.c raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/libs/ilclient/ilcore.c
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilcore.c	2014-08-08 15:48:28.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/libs/ilclient/ilcore.c	2015-03-08 11:34:40.252711405 +0000
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilcore.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/ilclient/ilcore.c
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilcore.c	2014-08-08 15:48:28.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/ilclient/ilcore.c	2015-03-08 11:34:40.252711405 +0000
 @@ -40,12 +40,12 @@
  #include <stdlib.h>
  #include <string.h>
- 
+
 -#include "IL/OMX_Component.h"
 -#include "interface/vcos/vcos.h"
 +#include <IL/OMX_Component.h>
 +#include <interface/vcos/vcos.h>
- 
+
 -#include "interface/vmcs_host/vcilcs.h"
 -#include "interface/vmcs_host/vchost.h"
 -#include "interface/vmcs_host/vcilcs_common.h"
 +#include <interface/vmcs_host/vcilcs.h>
 +#include <interface/vmcs_host/vchost.h>
 +#include <interface/vmcs_host/vcilcs_common.h>
- 
+
  static int coreInit = 0;
  static int nActiveHandles = 0;
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/libs/vgfont/graphics_x_private.h raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/libs/vgfont/graphics_x_private.h
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/libs/vgfont/graphics_x_private.h	2014-08-08 15:48:28.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/libs/vgfont/graphics_x_private.h	2015-03-08 11:30:08.646187422 +0000
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/vgfont/graphics_x_private.h raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/vgfont/graphics_x_private.h
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/vgfont/graphics_x_private.h	2014-08-08 15:48:28.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/vgfont/graphics_x_private.h	2015-03-08 11:30:08.646187422 +0000
 @@ -32,13 +32,13 @@
- 
+
  #define VCOS_LOG_CATEGORY (&gx_log_cat)
- 
+
 -#include "EGL/egl.h"
 -#include "EGL/eglext.h"
 -#include "VG/openvg.h"
@@ -287,19 +287,19 @@ diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi
 +#include <EGL/eglext.h>
 +#include <VG/openvg.h>
 +#include <VG/vgu.h>
- 
+
  #include "vgfont.h"
 -#include "bcm_host.h"
 +#include <bcm_host.h>
- 
+
  extern VCOS_LOG_CAT_T gx_log_cat;
- 
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/libs/vgfont/vgfont.h raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/libs/vgfont/vgfont.h
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/libs/vgfont/vgfont.h	2014-08-08 15:48:28.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/libs/vgfont/vgfont.h	2015-03-08 11:32:14.599212811 +0000
+
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/vgfont/vgfont.h raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/vgfont/vgfont.h
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/vgfont/vgfont.h	2014-08-08 15:48:28.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/vgfont/vgfont.h	2015-03-08 11:32:14.599212811 +0000
 @@ -31,9 +31,9 @@
  #define VCFTLIB_H
- 
+
  #include <stdint.h>
 -#include "interface/vmcs_host/vc_dispservice_x_defs.h"
 -#include "interface/vctypes/vc_image_types.h"
@@ -307,33 +307,33 @@ diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi
 +#include <interface/vmcs_host/vc_dispservice_x_defs.h>
 +#include <interface/vctypes/vc_image_types.h>
 +#include <interface/vcos/vcos.h>
- 
+
  //Definitions which in certain functions can be used to mean the actual width and height of a resource, without
  //having to know the data implicitly.
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/libs/vgfont/vgft.h raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/libs/vgfont/vgft.h
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/libs/vgfont/vgft.h	2014-08-23 17:33:49.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/libs/vgfont/vgft.h	2015-03-08 11:32:49.685055572 +0000
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/vgfont/vgft.h raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/vgfont/vgft.h
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/vgfont/vgft.h	2014-08-23 17:33:49.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/vgfont/vgft.h	2015-03-08 11:32:49.685055572 +0000
 @@ -30,7 +30,7 @@
  #ifndef VGFT_H
  #define VGFT_H
- 
+
 -#include "interface/vcos/vcos.h"
 +#include <interface/vcos/vcos.h>
  #include <VG/openvg.h>
  #include <ft2build.h>
- 
-diff -ur raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/Makefile.include raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/Makefile.include
---- raspberrypi-userland-2fa36bf.orig/host_applications/linux/apps/hello_pi/Makefile.include	2014-09-29 12:11:12.000000000 +0100
-+++ raspberrypi-userland-2fa36bf/host_applications/linux/apps/hello_pi/Makefile.include	2015-03-08 11:14:43.528966129 +0000
+
+diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/Makefile.include raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/Makefile.include
+--- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/Makefile.include	2014-09-29 12:11:12.000000000 +0100
++++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/Makefile.include	2015-03-08 11:14:43.528966129 +0000
 @@ -1,9 +1,9 @@
- 
+
  CFLAGS+=-DSTANDALONE -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -DTARGET_POSIX -D_LINUX -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -U_FORTIFY_SOURCE -Wall -g -DHAVE_LIBOPENMAX=2 -DOMX -DOMX_SKIP64BIT -ftree-vectorize -pipe -DUSE_EXTERNAL_OMX -DHAVE_LIBBCM_HOST -DUSE_EXTERNAL_LIBBCM_HOST -DUSE_VCHIQ_ARM -Wno-psabi
- 
+
 -LDFLAGS+=-L$(SDKSTAGE)/opt/vc/lib/ -lGLESv2 -lEGL -lopenmaxil -lbcm_host -lvcos -lvchiq_arm -lpthread -lrt -lm -L../libs/ilclient -L../libs/vgfont
 +LDFLAGS+=-L$(SDKSTAGE)/usr/lib/vc -lGLESv2 -lEGL -lopenmaxil -lbcm_host -lvcos -lvchiq_arm -lpthread -lrt -lm -L../libs/ilclient -L../libs/vgfont
- 
+
 -INCLUDES+=-I$(SDKSTAGE)/opt/vc/include/ -I$(SDKSTAGE)/opt/vc/include/interface/vcos/pthreads -I$(SDKSTAGE)/opt/vc/include/interface/vmcs_host/linux -I./ -I../libs/ilclient -I../libs/vgfont
 +INCLUDES+=-I$(SDKSTAGE)/usr/include/vc -I$(SDKSTAGE)/usr/include/vc/interface/vcos/pthreads -I$(SDKSTAGE)/usr/include/vc/interface/vmcs_host/linux -I./ -I../libs/ilclient -I../libs/vgfont
- 
+
  all: $(BIN) $(LIB)
- 
+

--- a/raspberrypi-vc-demo-source-path-fixup.patch
+++ b/raspberrypi-vc-demo-source-path-fixup.patch
@@ -1,6 +1,6 @@
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_audio/audio.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_audio/audio.c
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_audio/audio.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_audio/audio.c	2015-03-08 11:14:43.518965889 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_audio/audio.c userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_audio/audio.c
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_audio/audio.c	2014-08-08 15:48:27.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_audio/audio.c	2015-03-08 11:14:43.518965889 +0000
 @@ -34,7 +34,7 @@
  #include <unistd.h>
  #include <semaphore.h>
@@ -10,9 +10,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
  #include "ilclient.h"
 
  #define N_WAVE          1024    /* dimension of Sinewave[] */
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_dispmanx/dispmanx.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_dispmanx/dispmanx.c
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_dispmanx/dispmanx.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_dispmanx/dispmanx.c	2015-03-08 11:14:43.518965889 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_dispmanx/dispmanx.c userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_dispmanx/dispmanx.c
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_dispmanx/dispmanx.c	2014-08-08 15:48:27.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_dispmanx/dispmanx.c	2015-03-08 11:14:43.518965889 +0000
 @@ -34,7 +34,7 @@
  #include <unistd.h>
  #include <sys/time.h>
@@ -22,9 +22,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
 
  #define WIDTH   200
  #define HEIGHT  200
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_encode/encode.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_encode/encode.c
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_encode/encode.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_encode/encode.c	2015-03-08 11:21:13.318328860 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_encode/encode.c userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_encode/encode.c
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_encode/encode.c	2014-08-08 15:48:27.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_encode/encode.c	2015-03-08 11:21:13.318328860 +0000
 @@ -33,7 +33,7 @@
  #include <stdlib.h>
  #include <string.h>
@@ -34,9 +34,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
  #include "ilclient.h"
 
  #define NUMFRAMES 300
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_font/main.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_font/main.c
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_font/main.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_font/main.c	2015-03-08 11:21:38.953944627 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_font/main.c userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_font/main.c
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_font/main.c	2014-08-08 15:48:27.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_font/main.c	2015-03-08 11:21:38.953944627 +0000
 @@ -33,7 +33,7 @@
  #include <assert.h>
  #include <unistd.h>
@@ -46,9 +46,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
  #include "vgfont.h"
 
  static const char *strnchr(const char *str, size_t len, char c)
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_jpeg/jpeg.h raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_jpeg/jpeg.h
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_jpeg/jpeg.h	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_jpeg/jpeg.h	2015-03-08 11:22:19.159910374 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_jpeg/jpeg.h userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_jpeg/jpeg.h
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_jpeg/jpeg.h	2014-08-08 15:48:27.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_jpeg/jpeg.h	2015-03-08 11:22:19.159910374 +0000
 @@ -40,7 +40,7 @@
  #include <string.h>
  #include <errno.h>
@@ -58,9 +58,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
  #include "ilclient.h"
 
  #define OMXJPEG_OK                  0
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_teapot/models.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_teapot/models.c
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_teapot/models.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_teapot/models.c	2015-03-08 11:27:36.987544586 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_teapot/models.c userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_teapot/models.c
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_teapot/models.c	2014-08-08 15:48:27.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_teapot/models.c	2015-03-08 11:27:36.987544586 +0000
 @@ -29,9 +29,9 @@
  #include <stdio.h>
  #include <stdint.h>
@@ -74,9 +74,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
  #include "models.h"
 
  #define VMCS_RESOURCE(a,b) (b)
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c	2015-03-08 11:27:10.751914406 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c	2014-08-08 15:48:27.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c	2015-03-08 11:27:10.751914406 +0000
 @@ -35,11 +35,11 @@
  #include <assert.h>
  #include <unistd.h>
@@ -93,9 +93,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
 
  #include "cube_texture_and_coords.h"
  #include "models.h"
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_teapot/video.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_teapot/video.c
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_teapot/video.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_teapot/video.c	2015-03-08 11:22:40.915432941 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_teapot/video.c userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_teapot/video.c
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_teapot/video.c	2014-08-08 15:48:27.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_teapot/video.c	2015-03-08 11:22:40.915432941 +0000
 @@ -32,7 +32,7 @@
  #include <stdlib.h>
  #include <string.h>
@@ -105,9 +105,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
  #include "ilclient.h"
 
  static OMX_BUFFERHEADERTYPE* eglBuffer = NULL;
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_tiger/main.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_tiger/main.c
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_tiger/main.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_tiger/main.c	2015-03-08 11:28:31.458852985 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_tiger/main.c userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_tiger/main.c
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_tiger/main.c	2014-08-08 15:48:27.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_tiger/main.c	2015-03-08 11:28:31.458852985 +0000
 @@ -41,13 +41,13 @@
  #define UNREF(X) ((void)(X))
 
@@ -137,9 +137,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
  int main(void)
  {
     uint32_t width, height;
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_triangle/triangle.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_triangle/triangle.c
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_triangle/triangle.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_triangle/triangle.c	2015-03-08 11:29:00.839558709 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_triangle/triangle.c userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_triangle/triangle.c
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_triangle/triangle.c	2014-08-08 15:48:27.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_triangle/triangle.c	2015-03-08 11:29:00.839558709 +0000
 @@ -34,11 +34,11 @@
  #include <assert.h>
  #include <unistd.h>
@@ -156,9 +156,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
 
  #include "cube_texture_and_coords.h"
 
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c	2014-08-08 15:48:27.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c	2015-03-08 11:14:43.523966009 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c	2014-08-08 15:48:27.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c	2015-03-08 11:14:43.523966009 +0000
 @@ -36,11 +36,11 @@
  #include <assert.h>
  #include <unistd.h>
@@ -175,9 +175,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
 
  typedef struct
  {
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_video/video.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_video/video.c
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_video/video.c	2014-08-08 15:48:28.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_video/video.c	2015-03-08 11:14:43.528966129 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_video/video.c userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_video/video.c
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_video/video.c	2014-08-08 15:48:28.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_video/video.c	2015-03-08 11:14:43.528966129 +0000
 @@ -31,7 +31,7 @@
  #include <stdlib.h>
  #include <string.h>
@@ -187,9 +187,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
  #include "ilclient.h"
 
  static int video_decode_test(char *filename)
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c	2014-08-08 15:48:28.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c	2015-03-08 11:29:38.625466325 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c	2014-08-08 15:48:28.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c	2015-03-08 11:29:38.625466325 +0000
 @@ -35,11 +35,11 @@
  #include <assert.h>
  #include <unistd.h>
@@ -206,9 +206,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
 
  #include "cube_texture_and_coords.h"
 
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_videocube/video.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_videocube/video.c
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/hello_videocube/video.c	2014-08-08 15:48:28.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/hello_videocube/video.c	2015-03-08 11:24:28.093007343 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_videocube/video.c userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_videocube/video.c
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/hello_videocube/video.c	2014-08-08 15:48:28.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/hello_videocube/video.c	2015-03-08 11:24:28.093007343 +0000
 @@ -32,7 +32,7 @@
  #include <stdlib.h>
  #include <string.h>
@@ -218,9 +218,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
  #include "ilclient.h"
 
  static OMX_BUFFERHEADERTYPE* eglBuffer = NULL;
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.c
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.c	2014-08-08 15:48:28.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.c	2015-03-08 11:33:36.606182617 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.c userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.c
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.c	2014-08-08 15:48:28.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.c	2015-03-08 11:33:36.606182617 +0000
 @@ -47,11 +47,11 @@
  #include <ctype.h>
  #include <assert.h>
@@ -237,9 +237,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
  #include "ilclient.h"
 
  #define VCOS_LOG_CATEGORY (&ilclient_log_category)
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.h raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.h
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.h	2014-08-08 15:48:28.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.h	2015-03-08 11:34:04.476852069 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.h userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.h
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.h	2014-08-08 15:48:28.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/libs/ilclient/ilclient.h	2015-03-08 11:34:04.476852069 +0000
 @@ -43,8 +43,8 @@
  #ifndef _IL_CLIENT_H
  #define _IL_CLIENT_H
@@ -251,9 +251,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
 
  /**
   * The <DFN>ILCLIENT_T</DFN> structure encapsulates the state needed for the IL
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilcore.c raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/ilclient/ilcore.c
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilcore.c	2014-08-08 15:48:28.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/ilclient/ilcore.c	2015-03-08 11:34:40.252711405 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilcore.c userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/libs/ilclient/ilcore.c
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/libs/ilclient/ilcore.c	2014-08-08 15:48:28.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/libs/ilclient/ilcore.c	2015-03-08 11:34:40.252711405 +0000
 @@ -40,12 +40,12 @@
  #include <stdlib.h>
  #include <string.h>
@@ -272,9 +272,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
 
  static int coreInit = 0;
  static int nActiveHandles = 0;
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/vgfont/graphics_x_private.h raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/vgfont/graphics_x_private.h
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/vgfont/graphics_x_private.h	2014-08-08 15:48:28.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/vgfont/graphics_x_private.h	2015-03-08 11:30:08.646187422 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/libs/vgfont/graphics_x_private.h userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/libs/vgfont/graphics_x_private.h
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/libs/vgfont/graphics_x_private.h	2014-08-08 15:48:28.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/libs/vgfont/graphics_x_private.h	2015-03-08 11:30:08.646187422 +0000
 @@ -32,13 +32,13 @@
 
  #define VCOS_LOG_CATEGORY (&gx_log_cat)
@@ -294,9 +294,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
 
  extern VCOS_LOG_CAT_T gx_log_cat;
 
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/vgfont/vgfont.h raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/vgfont/vgfont.h
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/vgfont/vgfont.h	2014-08-08 15:48:28.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/vgfont/vgfont.h	2015-03-08 11:32:14.599212811 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/libs/vgfont/vgfont.h userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/libs/vgfont/vgfont.h
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/libs/vgfont/vgfont.h	2014-08-08 15:48:28.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/libs/vgfont/vgfont.h	2015-03-08 11:32:14.599212811 +0000
 @@ -31,9 +31,9 @@
  #define VCFTLIB_H
 
@@ -310,9 +310,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
 
  //Definitions which in certain functions can be used to mean the actual width and height of a resource, without
  //having to know the data implicitly.
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/vgfont/vgft.h raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/vgfont/vgft.h
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/libs/vgfont/vgft.h	2014-08-23 17:33:49.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/libs/vgfont/vgft.h	2015-03-08 11:32:49.685055572 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/libs/vgfont/vgft.h userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/libs/vgfont/vgft.h
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/libs/vgfont/vgft.h	2014-08-23 17:33:49.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/libs/vgfont/vgft.h	2015-03-08 11:32:49.685055572 +0000
 @@ -30,7 +30,7 @@
  #ifndef VGFT_H
  #define VGFT_H
@@ -322,9 +322,9 @@ diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi
  #include <VG/openvg.h>
  #include <ft2build.h>
 
-diff -ur raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/Makefile.include raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/Makefile.include
---- raspberrypi-userland-8369e39.orig/host_applications/linux/apps/hello_pi/Makefile.include	2014-09-29 12:11:12.000000000 +0100
-+++ raspberrypi-userland-8369e39/host_applications/linux/apps/hello_pi/Makefile.include	2015-03-08 11:14:43.528966129 +0000
+diff -ur userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/Makefile.include userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/Makefile.include
+--- userland-8369e390999f4a7c3bc57e577247e0dd502c51f7.orig/host_applications/linux/apps/hello_pi/Makefile.include	2014-09-29 12:11:12.000000000 +0100
++++ userland-8369e390999f4a7c3bc57e577247e0dd502c51f7/host_applications/linux/apps/hello_pi/Makefile.include	2015-03-08 11:14:43.528966129 +0000
 @@ -1,9 +1,9 @@
 
  CFLAGS+=-DSTANDALONE -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -DTARGET_POSIX -D_LINUX -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -U_FORTIFY_SOURCE -Wall -g -DHAVE_LIBOPENMAX=2 -DOMX -DOMX_SKIP64BIT -ftree-vectorize -pipe -DUSE_EXTERNAL_OMX -DHAVE_LIBBCM_HOST -DUSE_EXTERNAL_LIBBCM_HOST -DUSE_VCHIQ_ARM -Wno-psabi

--- a/raspberrypi-vc.spec
+++ b/raspberrypi-vc.spec
@@ -90,7 +90,7 @@ Static versions of libraries for accessing the BCM283x VideoCore GPU on the Rasp
 
 
 %prep
-%autosetup -n userland-%{commit_long}
+%setup -n userland-%{commit_long}
 
 %patch0 -p1
 

--- a/raspberrypi-vc.spec
+++ b/raspberrypi-vc.spec
@@ -410,6 +410,7 @@ popd # build
    from first 80K block.
   firmware: video_render: Fix for stereo rendering when crop height is not
    populated.
+
 * Sun Aug 10 2014 Clive Messer <clive.messer@squeezecommunity.org> - 20140810gitdf36e8d-501.rpfr20
 - Add 'Provides: libvcsm.so' to libs sub-package.
 - updated to firmware/userland to latest commit

--- a/raspberrypi-vc.spec
+++ b/raspberrypi-vc.spec
@@ -1,6 +1,6 @@
 # actually, the date is the date packaged, not the commit date
-%global commit_date	20160205
-%global commit_long	2a4af2192c0e161555fdb2a12e902b587166c4a6
+%global commit_date	20160305
+%global commit_long	8369e390999f4a7c3bc57e577247e0dd502c51f7
 %global commit_short	%(c=%{commit_long}; echo ${c:0:7})
 
 Name:		raspberrypi-vc
@@ -8,8 +8,8 @@ Version:	%{commit_date}
 Release:	1.%{commit_short}%{dist}
 Summary:	VideoCore GPU libraries, utilities and demos for Raspberry Pi
 License:	Redistributable, with restrictions; see LICENSE.broadcom
-URL:		https://github.com/raspberrypi
-Source0:	raspberrypi-userland-%{commit_short}.tar.xz
+URL:      https://github.com/raspberrypi
+Source0:	https://github.com/raspberrypi/userland/archive/%{commit_long}.tar.gz#/raspberrypi-userland-%{commit_short}.tar.gz
 Source1:	raspberrypi-vc-libs.conf
 
 # Patch0 fixes up paths for relocation from /opt to system directories.
@@ -103,7 +103,7 @@ make %{?_smp_mflags} all
 %install
 rm -rf %{buildroot}
 
-pushd build 
+pushd build
 make install DESTDIR=%{buildroot}
 
 # /opt/vc -> /usr
@@ -167,6 +167,9 @@ popd # build
 %doc LICENCE
 
 %changelog
+* Sun Mar 05 2016 mrjoshuap <jpreston at redhat dot com> - 20160305-1.8369e39
+- Sync to latest git revision: 8369e390999f4a7c3bc57e577247e0dd502c51f7
+
 * Fri Feb 05 2016 Vaughan <devel at agrez dot net> - 20160205-1.2a4af21
 - Sync to latest git revision: 2a4af2192c0e161555fdb2a12e902b587166c4a6
 
@@ -196,7 +199,7 @@ popd # build
   mmal_queue: Add sanity checking to avoid common queue errors
 - Git revision master d0954df802d43ea7cc94481435188913f6a65eee
   Add MMAL to IL mapping for rawcam parameters
-  
+
   * Tue May 26 2015 Clive Messer <clive.messer@squeezecommunity.org> - 20150526-502.gitd4aa617
 - Remove the hard-coded provides.
 
@@ -216,15 +219,15 @@ popd # build
   Merge pull request #241 from nubok/patch-1
   Added "all" target to hello_fft/makefile
 - Git revision master 74a6acf296bd814760b4b33f31925087e2a55cc0
-  Added "all" target to hello_fft/makefile    
-  Same patch as https://github.com/raspberrypi/firmware/pull/422 for the 
-   firmware repository: The reason, why I added a new target "all" is that 
-   without it, the script /opt/vc/src/hello_pi/rebuild.sh only builds 
+  Added "all" target to hello_fft/makefile
+  Same patch as https://github.com/raspberrypi/firmware/pull/422 for the
+   firmware repository: The reason, why I added a new target "all" is that
+   without it, the script /opt/vc/src/hello_pi/rebuild.sh only builds
    hello_fft.bin, but not hello_fft_2d.bin.
 
 * Wed Apr 29 2015 Clive Messer <clive.messer@squeezecommunity.org> - 20150429-501.gitd8f146a.sc20
 - Git revision master d8f146af05c2b9cd92f9a426148376b349f744fd
-  Merge pull request #240 from 6by9/master    
+  Merge pull request #240 from 6by9/master
   Zero copy, and buildme change for Pi2
 - Git revision master e8707f827c0e4ae5de892ac700b5bdb649350a1a
   Enable VCSM in MMAL by default
@@ -233,20 +236,20 @@ popd # build
 
 * Fri Apr 24 2015 Clive Messer <clive.messer@squeezecommunity.org> - 20150424-501.git198b9ac.sc20
 - Git revision master 198b9ac3bcc0b54f1563664870fe415f04b7b6b5
-  Merge pull request #239 from thaytan/master    
+  Merge pull request #239 from thaytan/master
   Fix intra-refresh port parameter setting.
 - Git revision master 41b2b2918f08fbf7603e6f52120fff5bb6cc802c
-  Fix intra-refresh port parameter setting.    
+  Fix intra-refresh port parameter setting.
   check mmal_port_parameter_get() succeeds when getting
-   the default intra refresh values. It fails on older firmware.    
+   the default intra refresh values. It fails on older firmware.
   Fixes #238
 
 * Sat Apr 18 2015 Clive Messer <clive.messer@squeezecommunity.org> - 20150418gitb69f807-501.sc20
 - Git revision master b69f807ce59189457662c2144a8e7e12dc776988
-  Merge pull request #237 from MarkusMattinen/patch-1    
+  Merge pull request #237 from MarkusMattinen/patch-1
   Fix typo in buildme shebang
 - Git revision master 36a20b6d92790a530421cb319a83ff9be79509d3
-  Fix typo in buildme shebang    
+  Fix typo in buildme shebang
   Fixes #176.
 
 * Sun Apr 12 2015 Clive Messer <clive.messer@squeezecommunity.org> - 20150412gitb4f537b-501.sc20
@@ -257,7 +260,7 @@ popd # build
 
 * Tue Mar 17 2015 Clive Messer <clive.messer@squeezecommunity.org> - 20150323git7650bcb-501.sc20
 - Git revision master 7650bcbc9ba8f1c5e29be7726d184b31c2665c46
-  Merge pull request #233 from jsonn/patch-1    
+  Merge pull request #233 from jsonn/patch-1
   Use a more sensible check than a tautoligy
 - Git revision master 9b45a317b0ab56e83dfc228b6cd5800a0078835f
   Merge pull request #234 from jsonn/patch-2
@@ -279,7 +282,7 @@ popd # build
   Merge pull request #226 from 6by9/PR20150310
   Add an error message for MMAL_EVENT_ERROR
 - Git revision master 695e11ced1e286d945f7dfcebae484ef3848a830
-  Add an error message for MMAL_EVENT_ERROR    
+  Add an error message for MMAL_EVENT_ERROR
   It is signalled by the camera when no data is received on the CSI-2
    bus. Handle it specifically to try and avoid a bundle of duplicate
    forum posts.
@@ -394,18 +397,18 @@ popd # build
 * Wed Aug 13 2014 Clive Messer <clive.messer@squeezecommunity.org> - 20140813git43c5b2f-501.rpfr20
 - Updated firmware to latest commit 43c5b2fc9bdb0a43ba67661b8677445e71ae9e82
   kernel/libs: VCHIQ: Make service closure fully synchronous
-   With these patches, calls to vchiq_close_service and vchiq_remove_service 
-    won't return until any associated callback have been delivered to the 
-    callback thread.  
+   With these patches, calls to vchiq_close_service and vchiq_remove_service
+    won't return until any associated callback have been delivered to the
+    callback thread.
   firmware: video_render: Add parameter for setting the colourspace
    Only applicable for non-opaque buffers.
   firmware: gpioman: Allow oscillator to be selected as a clock source
-  firmware: image_decode: huffman and quantization tables shouldn't trigger 
-   'keep all following'. 
+  firmware: image_decode: huffman and quantization tables shouldn't trigger
+   'keep all following'.
    See: http://forum.stmlabs.com/showthread.php?tid=14839
-  userland: hello_jpeg: Fix decode fail when width/height can't be parsed 
+  userland: hello_jpeg: Fix decode fail when width/height can't be parsed
    from first 80K block.
-  firmware: video_render: Fix for stereo rendering when crop height is not 
+  firmware: video_render: Fix for stereo rendering when crop height is not
    populated.
 * Sun Aug 10 2014 Clive Messer <clive.messer@squeezecommunity.org> - 20140810gitdf36e8d-501.rpfr20
 - Add 'Provides: libvcsm.so' to libs sub-package.
@@ -488,13 +491,13 @@ popd # build
 - Updated to upstream, added suid on utils
 
 * Fri Apr 19 2013 andrew.greene@senecacollege.ca - 20130410git7fcb9d3-2.rpfr18
-- Included provides for libs libmmal_core and libmmal_util these are needed for vc-utils 
+- Included provides for libs libmmal_core and libmmal_util these are needed for vc-utils
 
 * Tue Apr 16 2013 andrew.greene@senecacollege.ca - 20130410git7fcb9d3eb2-1.rpfr18
 - Updated to latest version changed vchost_config.h location
 
 * Sat Mar 02 2013 andrew.greene@senecacollege.ca - 20121125git7e9ac50-7.rpfr18
-- Copied missing header file to the correct location vchost_config.h vcos_platform_types.h and vcos_platform.h 
+- Copied missing header file to the correct location vchost_config.h vcos_platform_types.h and vcos_platform.h
 
 * Fri Mar 01 2013 andrew.greene@senecacollege.ca - 20121125git7e9ac50-4.rpfr18
 - rebuilt for armv6hl

--- a/raspberrypi-vc.spec
+++ b/raspberrypi-vc.spec
@@ -90,7 +90,7 @@ Static versions of libraries for accessing the BCM283x VideoCore GPU on the Rasp
 
 
 %prep
-%setup -q -n raspberrypi-userland-%{commit_short}
+%autosetup -n userland-%{commit_long}
 
 %patch0 -p1
 

--- a/raspberrypi-vc.spec
+++ b/raspberrypi-vc.spec
@@ -90,7 +90,7 @@ Static versions of libraries for accessing the BCM283x VideoCore GPU on the Rasp
 
 
 %prep
-%setup -q -c -n raspberrypi-userland-%{commit_short}
+%setup -q -n raspberrypi-userland-%{commit_short}
 
 %patch0 -p1
 


### PR DESCRIPTION
see https://github.com/raspberrypi/userland/tree/8369e390999f4a7c3bc57e577247e0dd502c51f7
- removed archive from repo - you should specify `spectool -g -R raspberrypi-vc.spec` to download sources
- reworked patch to correct version
